### PR TITLE
Hide BIC in bank details if empty

### DIFF
--- a/docs/docs/api-reference/components.md
+++ b/docs/docs/api-reference/components.md
@@ -21,17 +21,21 @@ Defines and renders the bank account information for payments. It can optionally
 If you leave `payment-amount` set to `auto`, the component will automatically fetch the final gross total of the invoice and use it for the display and the QR code!
 :::
 
-| Key                   | Type                         | Description                                                                                                                    |
-| --------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `name`                | `auto` \| `none` \| `str`    | The name of the account holder. If set to `auto`, it automatically defaults to the sender's name.                              |
-| `bank`                | `none` \| `str`              | The name of the banking institution.                                                                                           |
-| `iban`                | `none` \| `str`              | The International Bank Account Number (IBAN).                                                                                  |
-| `bic`                 | `none` \| `str`              | The Bank Identifier Code (BIC/SWIFT).                                                                                          |
-| `reference`           | `auto` \| `none` \| `str`    | The payment reference to be used by the customer.                                                                              |
-| `payment-amount`      | `auto` \| `none` \| `number` | The specific amount to be paid. If `auto`, it uses the document's total gross amount.                                          |
-| `show-reference`      | `bool`                       | Whether to display the reference field in the output. Defaults to `true`.                                                      |
-| `account-holder-text` | `auto`                       | Optional custom text to label the account holder field.                                                                        |
-| `qr-code`             | `dictionary`                 | Configuration for a payment QR code (e.g., EPC-QR). Accepts keys like `display` (bool) and `size` (length, defaults to `5em`). |
+:::note
+The `bic` parameter is optional. If not provided or set to `none`, the BIC row will not be displayed in the bank details block, and the EPC-QR code will be generated without a BIC.
+:::
+
+| Key                   | Type                         | Description                                                                                                                                     |
+| --------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                | `auto` \| `none` \| `str`    | The name of the account holder. If set to `auto`, it automatically defaults to the sender's name.                                               |
+| `bank`                | `none` \| `str`              | The name of the banking institution.                                                                                                            |
+| `iban`                | `none` \| `str`              | The International Bank Account Number (IBAN).                                                                                                   |
+| `bic`                 | `none` \| `str`              | The Bank Identifier Code (BIC/SWIFT). If omitted or `none`, the BIC field is hidden in the bank details block and omitted from the EPC-QR code. |
+| `reference`           | `auto` \| `none` \| `str`    | The payment reference to be used by the customer.                                                                                               |
+| `payment-amount`      | `auto` \| `none` \| `number` | The specific amount to be paid. If `auto`, it uses the document's total gross amount.                                                           |
+| `show-reference`      | `bool`                       | Whether to display the reference field in the output. Defaults to `true`.                                                                       |
+| `account-holder-text` | `auto`                       | Optional custom text to label the account holder field.                                                                                         |
+| `qr-code`             | `dictionary`                 | Configuration for a payment QR code (e.g., EPC-QR). Accepts keys like `display` (bool) and `size` (length, defaults to `5em`).                  |
 
 ---
 

--- a/src/components/bank-details.typ
+++ b/src/components/bank-details.typ
@@ -18,7 +18,7 @@
   /// -> none | string
   iban: none,
 
-  /// The Bank Identifier Code (BIC/SWIFT).
+  /// The Bank Identifier Code (BIC/SWIFT). If omitted or `none`, the BIC is not displayed in the bank details block.
   /// -> none | string
   bic: none,
 

--- a/src/themes/base-theme/bank-details.typ
+++ b/src/themes/base-theme/bank-details.typ
@@ -37,7 +37,7 @@
       #bd-str.account-holder: #view.sender.name \
       #bd-str.bank: #view.sender.bank \
       #bd-str.iban: *#ibanator.iban(view.sender.iban)* \
-      #bd-str.bic: #view.sender.bic \
+      #if view.sender.bic != "" [#bd-str.bic: #view.sender.bic \ ]
       #if (
         view.show-reference and view.reference != none
       ) [#bd-str.reference: *#view.reference*] \

--- a/tests/unit/test.typ
+++ b/tests/unit/test.typ
@@ -709,3 +709,44 @@
   ))
 }
 
+// --- Test bank-details BIC visibility ---
+#{
+  import "/src/themes/base-theme/bank-details.typ": render-bank-details
+  import "/src/lib.typ": locale
+  import "/src/locale/lang/base.typ": base-language
+  import "/src/locale/region/base.typ": base-region
+
+  let ctx = (
+    locale: (locale.de-de)(base-language, base-region),
+  )
+
+  let base-view = (
+    sender: (
+      name: "Max Mustermann",
+      bank: "Musterbank",
+      iban: "DE75512108001245126199",
+      bic: "",
+    ),
+    qr-code: (
+      size: 5em,
+      display: true,
+    ),
+    reference: "INV-001",
+    show-reference: true,
+    payment-amount: 100.0,
+  )
+
+  // 1. When BIC is empty / omitted, BIC line should not be rendered
+  let res-no-bic = render-bank-details(ctx, base-view)
+  let str-no-bic = repr(res-no-bic)
+  assert(not str-no-bic.contains("[BIC]"))
+  assert(not str-no-bic.contains("SOLADEST600"))
+
+  // 2. When BIC is provided, BIC line should be rendered
+  let view-with-bic = base-view
+  view-with-bic.sender.bic = "SOLADEST600"
+  let res-with-bic = render-bank-details(ctx, view-with-bic)
+  let str-with-bic = repr(res-with-bic)
+  assert(str-with-bic.contains("[BIC]"))
+  assert(str-with-bic.contains("SOLADEST600"))
+}


### PR DESCRIPTION
As the BIC is optional for EPC QR codes version 002, hide the BIC from the invoice when set to none.