### PR TITLE
Expose text in bank-details for unstructured remittance

### DIFF
--- a/src/components/bank-details.typ
+++ b/src/components/bank-details.typ
@@ -22,9 +22,13 @@
   /// -> none | string
   bic: none,
 
-  /// The payment reference to be used by the customer.
+  /// The structured payment reference to be used by the customer.
   /// -> auto | none | string
   reference: auto,
+
+  /// The unstructured payment reference text to be used by the customer.
+  /// -> none | string
+  text: none,
 
   /// The specific amount to be paid. If `auto`, it uses the document total.
   /// -> auto | none | decimal | float | int
@@ -48,6 +52,7 @@
   types.require(bic, "bank-details::bic", none, str)
 
   types.require(reference, "bank-details::reference", none, auto, str)
+  types.require(text, "bank-details::text", none, str)
   types.require(
     payment-amount,
     "bank-details::payment-amount",
@@ -57,6 +62,11 @@
   )
 
   types.require(show-reference, "bank-details::show-reference", bool)
+
+  assert(
+    (reference == auto or reference == none) or text == none,
+    message: "Cannot specify both 'reference' and 'text'. Use one or the other.",
+  )
 
   if name == none { name = "" }
   if iban == none { iban = "" }
@@ -74,8 +84,14 @@
 
       derive("sender", "name", name, default: "")
 
-      put("reference", ctx.invoice-nr)
-      derive("reference", reference)
+      if text != none {
+        put("text", text)
+        put("reference", none)
+      } else {
+        put("text", none)
+        put("reference", ctx.invoice-nr)
+        derive("reference", reference)
+      }
 
       nest("theme", {
         ensure("bank-details", (..) => panic(
@@ -104,6 +120,7 @@
         ),
 
         reference: ctx.reference,
+        text: ctx.text,
         show-reference: show-reference,
         payment-amount: if payment-amount == auto {
           ctx.global.total.gross
@@ -117,6 +134,7 @@
         iban: iban,
         bic: bic,
         reference: ctx.reference,
+        text: ctx.text,
       )
 
       (public, data)

--- a/src/themes/base-theme/bank-details.typ
+++ b/src/themes/base-theme/bank-details.typ
@@ -7,6 +7,8 @@
   let currency-code = ctx.locale.currency.code
 
   let qr-image = none
+  let remittance-text = view.at("text", default: none)
+  let reference = view.at("reference", default: none)
 
   if currency-code == "EUR" {
     qr-image = epc-qr-code(
@@ -20,8 +22,9 @@
         width: view.qr-code.size,
         height: view.qr-code.size,
       )
-        + if view.text != none { (text: view.text) } else if view.reference
-          != none { (reference: view.reference) },
+        + if remittance-text != none {
+          (text: remittance-text)
+        } else if reference != none { (reference: reference) },
     )
   }
 
@@ -40,10 +43,10 @@
       #bd-str.iban: *#ibanator.iban(view.sender.iban)* \
       #if view.sender.bic != "" [#bd-str.bic: #view.sender.bic \ ]
       #if (
-        view.show-reference and view.text != none
-      ) [#bd-str.reference: *#view.text*] else if (
-        view.show-reference and view.reference != none
-      ) [#bd-str.reference: *#view.reference*] \
+        view.show-reference and remittance-text != none
+      ) [#bd-str.reference: *#remittance-text*] else if (
+        view.show-reference and reference != none
+      ) [#bd-str.reference: *#reference*] \
       #h(6.5cm)
     ][
       #if view.qr-code.display {

--- a/src/themes/base-theme/bank-details.typ
+++ b/src/themes/base-theme/bank-details.typ
@@ -20,7 +20,7 @@
         width: view.qr-code.size,
         height: view.qr-code.size,
       )
-        + if view.reference != none { (reference: view.reference) },
+        + if view.text != none { (text: view.text) } else if view.reference != none { (reference: view.reference) },
     )
   }
 
@@ -39,6 +39,8 @@
       #bd-str.iban: *#ibanator.iban(view.sender.iban)* \
       #if view.sender.bic != "" [#bd-str.bic: #view.sender.bic \ ]
       #if (
+        view.show-reference and view.text != none
+      ) [#bd-str.reference: *#view.text*] else if (
         view.show-reference and view.reference != none
       ) [#bd-str.reference: *#view.reference*] \
       #h(6.5cm)

--- a/src/themes/base-theme/bank-details.typ
+++ b/src/themes/base-theme/bank-details.typ
@@ -20,7 +20,8 @@
         width: view.qr-code.size,
         height: view.qr-code.size,
       )
-        + if view.text != none { (text: view.text) } else if view.reference != none { (reference: view.reference) },
+        + if view.text != none { (text: view.text) } else if view.reference
+          != none { (reference: view.reference) },
     )
   }
 

--- a/tests/unit/test.typ
+++ b/tests/unit/test.typ
@@ -749,6 +749,14 @@
   let str-with-bic = repr(res-with-bic)
   assert(str-with-bic.contains("[BIC]"))
   assert(str-with-bic.contains("SOLADEST600"))
+
+  // 3. When unstructured text is provided instead of reference
+  let view-with-text = base-view
+  view-with-text.reference = none
+  view-with-text.text = "Rechnung 2026-001"
+  let res-with-text = render-bank-details(ctx, view-with-text)
+  let str-with-text = repr(res-with-text)
+  assert(str-with-text.contains("Rechnung 2026-001"))
 }
 
 


### PR DESCRIPTION
The EPC QR codes has two types of remittances:

* Structured reference (currently used by invoice-pro): Maximum of 35 characters
* Text: Maximum of 150 characters

This exposes the "text" property for `#bank-details()`, so it can be used to write longer unstructured remittances if wanted.

As only one of the both is allowed in a EPC QR code, it also adds an assert if both are explicitly set.